### PR TITLE
Add Django Rest CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [graphene-django](https://github.com/graphql-python/graphene-django) - GraphQL for Django.
 - [django-ninja](https://django-ninja.rest-framework.com/) - Django Ninja - Fast Django REST framework based on type annotations.
 - [django-tastypie](https://github.com/django-tastypie/django-tastypie) - Creating delicious APIs for Django apps since 2010.
+- [django-rest-cli](https://github.com/py-universe/django-rest-cli) - A CRUD endpoints generator and flexible cookiecutter for rapid REST APIs dev.
 <!--lint enable double-link-->
 
 ### Async


### PR DESCRIPTION
A CLI tool for _rapid_ Rest APIs development. It abstracts the repeated aspects of building a REST API with the Django Framework by:

- Allowing you start your project from one of three templates. Each template comes with features you'd most likely be setting up yourself already configured for you.

- Allowing you define your models and have this tool generate CRUD endpoints for each model defined.
For example, if you define a model, **Product** in your `models.py` file, this tool could generate a _GET /products POST /products PUT /products/<product_id>_ etc. endpoints for that model.

- Allowing you create all the apps in your project at once, if you know them before hand.